### PR TITLE
Slider addition to add_cube

### DIFF
--- a/moly/figure/figure.py
+++ b/moly/figure/figure.py
@@ -9,7 +9,7 @@ import plotly.graph_objects as go
 
 from ..layers.bonds import get_bonds
 from ..layers.geometry import get_atoms
-from ..layers.measurements import get_angle, get_line
+# from ..layers.measurements import get_angle, get_line
 from ..layers.cube import get_cubes, cube_to_molecule, get_cubes, get_cube_trace
 from .layouts import get_layout, get_range
 from .widgets import get_buttons, get_buttons_wfn
@@ -98,9 +98,36 @@ class Figure():
             #Add traces
             self.fig.add_trace(trace)
 
+        elif type(iso) == list or type(iso) == tuple:
+            steps = []
+            iso_traces = []
+            for i, step in enumerate(iso):
+                trace, min_range, max_range = get_cube_trace(cube, spacing, origin, step, colorscale, opacity)
+                if i != 0:
+                    trace.visible = False
+                self.fig.add_trace(trace)
+                iso_traces.append(trace)
+                one_step = dict(method="restyle", args=["visible", [False] * (len(iso))],)
+                one_step["args"][1][i] = True  # Toggle i'th trace to "visible"
+                steps.append(one_step)
+
+            sliders = [dict(
+                active=10,
+                currentvalue={"prefix": "Iso: "},
+                pad={"t": 50},
+                steps=steps
+            )]
+
+            self.fig.update_layout(get_layout(self.resolution), sliders=sliders)
+            
+            for i, ival in enumerate(iso, start = 0):
+                self.fig['layout']['sliders'][0]['steps'][i]['label'] = str(ival)[:5]
+
+
         #Update layout
-        self.fig.update_layout(get_layout(self.resolution))
+        self.fig.update_layout(get_layout(self.resolution), sliders=sliders)
         self.assert_range([min_range, max_range])
+
 
     def add_measurement(self, mol_label, m, 
                         line_width=20,

--- a/moly/figure/figure.py
+++ b/moly/figure/figure.py
@@ -76,13 +76,9 @@ class Figure():
 
     def add_cube(self, file, iso=0.01, plot_geometry=True, 
                  colorscale="portland", opacity=0.2, style="ball_and_stick"):
-        """Adds an isosurface plot to the figure from a cube file.
-
-        An isosurface is the three-dimensional analog of a contour line.
-        A cube file describes all the volumetric data required to plot this
-        isosurface. Therefore orbitals for molecules can be visualized at 
-        specific iso values. 
-
+        """
+        Adds an isosurface plot to the figure from a cube file.
+        
         Parameters
         ----------
         file : str
@@ -98,26 +94,18 @@ class Figure():
             The degree of transparency for the isosurface(s)
         style : str
             How bonds and atoms are represented within the plot
-
-        References
-        ----------
-        File Format
-            http://paulbourke.net/dataformats/cube/
-        Isosurface
-            https://en.wikipedia.org/wiki/Isosurface
         """
 
         geometry, symbols, atomic_numbers, spacing, origin, cube = cube_to_molecule(file)
     
-        bonds = qcel.molutil.guess_connectivity(symbols, geometry)
-        bond_list = get_bonds(geometry, symbols, bonds, style, self.surface)
-        atom_list = get_atoms(geometry, atomic_numbers, symbols, style, self.surface)
-
         if plot_geometry is True:
+            bonds = qcel.molutil.guess_connectivity(symbols, geometry)
+            bond_list = get_bonds(geometry, symbols, bonds, style, self.surface)
+            atom_list = get_atoms(geometry, atomic_numbers, symbols, style, self.surface)
+            
             #Add traces
             for bond in bond_list:
                 self.fig.add_trace(bond)
-
             for atom in atom_list:
                 self.fig.add_trace(atom)
 
@@ -126,21 +114,20 @@ class Figure():
             trace, min_range, max_range = get_cube_trace(cube, spacing, origin, iso, colorscale, opacity) 
             #Add traces
             self.fig.add_trace(trace)
-
+            
+        #Slider with multiple iso value
         elif type(iso) == list or type(iso) == tuple:
-            steps = []
-            # Number of current traces within figure (bonds and atoms)
-            n_traces = len(self.fig.data)
+            geometry_traces = len(self.fig.data)
             for i, iso_i in enumerate(iso):
                 if i == 0:
-                    trace, min_range, max_range = get_cube_trace(cube, spacing, origin, iso_i, colorscale, opacity)
+                    trace, min_range, max_range = get_cube_trace(cube, spacing, origin, iso_i, colorscale, opacity, visible=True)
                 elif i != 0:
                     trace, min_range, max_range = get_cube_trace(cube, spacing, origin, iso_i, colorscale, opacity, visible=False)
                 
                 self.fig.add_trace(trace)
 
-            sliders = get_slider(iso, n_traces)
-            self.fig.update_layout(get_layout(self.resolution), sliders=sliders)
+            slider = get_slider(iso, geometry_traces)
+            self.fig.update_layout(sliders=slider)
 
         #Update layout
         self.fig.update_layout(get_layout(self.resolution))

--- a/moly/figure/widgets.py
+++ b/moly/figure/widgets.py
@@ -38,20 +38,18 @@ def get_buttons_wfn(meta, geo_traces):
 
     return buttons
 
-def get_slider(iso, n_traces):
+def get_slider(iso, geometry_traces):
     steps = []
     for i, iso_i in enumerate(iso):
         one_step = {'method': "restyle", 
                     'label': str(iso_i), 
-                    'args': [{"visible": [True] * n_traces + [False] * len(iso)}]}
-        one_step["args"][0]['visible'][n_traces + i] = True
+                    'args': [{"visible": [True] * geometry_traces + [False] * len(iso)}]}
+        one_step["args"][0]['visible'][geometry_traces + i] = True
         steps.append(one_step)
 
-    sliders = [dict(
-        active=10,
-        currentvalue={"prefix": "Iso: "},
-        pad={"t": 50},
-        steps=steps
-    )]
+    sliders = [dict(active=len(geometry_traces),
+                    currentvalue={"prefix": "Iso: "},
+                    pad={"t": 50},
+                    steps=steps)]
 
     return sliders

--- a/moly/figure/widgets.py
+++ b/moly/figure/widgets.py
@@ -37,3 +37,21 @@ def get_buttons_wfn(meta, geo_traces):
         buttons.append(button)
 
     return buttons
+
+def get_slider(iso, n_traces):
+    steps = []
+    for i, iso_i in enumerate(iso):
+        one_step = {'method': "restyle", 
+                    'label': str(iso_i), 
+                    'args': [{"visible": [True] * n_traces + [False] * len(iso)}]}
+        one_step["args"][0]['visible'][n_traces + i] = True
+        steps.append(one_step)
+
+    sliders = [dict(
+        active=10,
+        currentvalue={"prefix": "Iso: "},
+        pad={"t": 50},
+        steps=steps
+    )]
+
+    return sliders


### PR DESCRIPTION
Changed around the code following your guidelines. Also felt like `np.linspace` was unnecessary as someone can just as easily paste into the parameter an `np.arange`, I think it is more clear this way. Also was able to remove the iso_steps parameter and iso_range, seemed like a lot of params for something simple.

I don't know why the 1c5af8d commit is in there, but the second commit 5f394a5 should be all good.